### PR TITLE
fixup! CrateDB vector: Add vector store support [dimension independence]

### DIFF
--- a/libs/langchain/langchain/vectorstores/cratedb/__init__.py
+++ b/libs/langchain/langchain/vectorstores/cratedb/__init__.py
@@ -1,9 +1,6 @@
 from .base import BaseModel, CrateDBVectorSearch
-from .model import CollectionStore, EmbeddingStore
 
 __all__ = [
     "BaseModel",
     "CrateDBVectorSearch",
-    "CollectionStore",
-    "EmbeddingStore",
 ]

--- a/libs/langchain/langchain/vectorstores/cratedb/model.py
+++ b/libs/langchain/langchain/vectorstores/cratedb/model.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import Optional, Tuple
 
 import sqlalchemy
@@ -8,70 +9,76 @@ from langchain.vectorstores.cratedb.base import BaseModel
 from langchain.vectorstores.cratedb.sqlalchemy_type import FloatVector
 
 
-class CollectionStore(BaseModel):
-    """Collection store."""
+@lru_cache
+def model_factory(dimensions: int):
+    class CollectionStore(BaseModel):
+        """Collection store."""
 
-    __tablename__ = "collection"
+        __tablename__ = "collection"
 
-    name = sqlalchemy.Column(sqlalchemy.String)
-    cmetadata: sqlalchemy.Column = sqlalchemy.Column(ObjectType)
+        name = sqlalchemy.Column(sqlalchemy.String)
+        cmetadata: sqlalchemy.Column = sqlalchemy.Column(ObjectType)
 
-    embeddings = relationship(
-        "EmbeddingStore",
-        back_populates="collection",
-        passive_deletes=True,
-    )
-
-    @classmethod
-    def get_by_name(cls, session: Session, name: str) -> Optional["CollectionStore"]:
-        return (
-            session.query(cls).filter(cls.name == name).first()  # type: ignore[attr-defined]  # noqa: E501
+        embeddings = relationship(
+            "EmbeddingStore",
+            back_populates="collection",
+            passive_deletes=True,
         )
 
-    @classmethod
-    def get_or_create(
-        cls,
-        session: Session,
-        name: str,
-        cmetadata: Optional[dict] = None,
-    ) -> Tuple["CollectionStore", bool]:
-        """
-        Get or create a collection.
-        Returns [Collection, bool] where the bool is True if the collection was created.
-        """
-        created = False
-        collection = cls.get_by_name(session, name)
-        if collection:
+        @classmethod
+        def get_by_name(
+            cls, session: Session, name: str
+        ) -> Optional["CollectionStore"]:
+            try:
+                return (
+                    session.query(cls).filter(cls.name == name).first()  # type: ignore[attr-defined]  # noqa: E501
+                )
+            except sqlalchemy.exc.ProgrammingError as ex:
+                if "RelationUnknown" not in str(ex):
+                    raise
+            return None
+
+        @classmethod
+        def get_or_create(
+            cls,
+            session: Session,
+            name: str,
+            cmetadata: Optional[dict] = None,
+        ) -> Tuple["CollectionStore", bool]:
+            """
+            Get or create a collection.
+            Returns [Collection, bool] where the bool is True if the collection was created.
+            """
+            created = False
+            collection = cls.get_by_name(session, name)
+            if collection:
+                return collection, created
+
+            collection = cls(name=name, cmetadata=cmetadata)
+            session.add(collection)
+            session.commit()
+            created = True
             return collection, created
 
-        collection = cls(name=name, cmetadata=cmetadata)
-        session.add(collection)
-        session.commit()
-        created = True
-        return collection, created
+    class EmbeddingStore(BaseModel):
+        """Embedding store."""
 
+        __tablename__ = "embedding"
 
-class EmbeddingStore(BaseModel):
-    """Embedding store."""
+        collection_id = sqlalchemy.Column(
+            sqlalchemy.String,
+            sqlalchemy.ForeignKey(
+                f"{CollectionStore.__tablename__}.uuid",
+                ondelete="CASCADE",
+            ),
+        )
+        collection = relationship("CollectionStore", back_populates="embeddings")
 
-    __tablename__ = "embedding"
+        embedding = sqlalchemy.Column(FloatVector(dimensions))
+        document = sqlalchemy.Column(sqlalchemy.String, nullable=True)
+        cmetadata: sqlalchemy.Column = sqlalchemy.Column(ObjectType, nullable=True)
 
-    collection_id = sqlalchemy.Column(
-        sqlalchemy.String,
-        sqlalchemy.ForeignKey(
-            f"{CollectionStore.__tablename__}.uuid",
-            ondelete="CASCADE",
-        ),
-    )
-    collection = relationship(CollectionStore, back_populates="embeddings")
+        # custom_id : any user defined id
+        custom_id = sqlalchemy.Column(sqlalchemy.String, nullable=True)
 
-    # FIXME: `pgvector` uses `Vector(None)` here.
-    #        CrateDB is not agnostic to the amount of dimensions,
-    #        and will fail with `expected 1024 dimensions, not XX`,
-    #        when trying to store a vector with different dimensions.
-    embedding = sqlalchemy.Column(FloatVector(1024))
-    document = sqlalchemy.Column(sqlalchemy.String, nullable=True)
-    cmetadata: sqlalchemy.Column = sqlalchemy.Column(ObjectType, nullable=True)
-
-    # custom_id : any user defined id
-    custom_id = sqlalchemy.Column(sqlalchemy.String, nullable=True)
+    return CollectionStore, EmbeddingStore


### PR DESCRIPTION
## About

On the first iteration, we hard-coded the dimension size of the vector column to 1024.

```python
# FIXME: `pgvector` uses `Vector(None)` here.
#        CrateDB is not agnostic to the amount of dimensions,
#        and will fail with `expected 1024 dimensions, not XX`,
#        when trying to store a vector with different dimensions.
embedding = sqlalchemy.Column(FloatVector(1024))
```

With this patch, it will be derived from the first actual embedding vector being stored. The software tests seem to accept the change, and I am curious if that also works well in practice.

## Setup

The package can be installed/upgraded to the version on this feature branch by using that command:
```shell
pip install --upgrade 'git+https://github.com/crate-workbench/langchain@dimension-independence#egg=langchain[openai]&subdirectory=libs/langchain'
```

/cc @karynzv, @marijaselakovic, @andnig, @ckurze, @seut, @matriv 

