### PR TITLE
CrateDB vector: Fix cascading deletes

### DIFF
--- a/libs/langchain/langchain/vectorstores/cratedb/model.py
+++ b/libs/langchain/langchain/vectorstores/cratedb/model.py
@@ -45,7 +45,8 @@ class ModelFactory:
             embeddings = relationship(
                 "EmbeddingStore",
                 back_populates="collection",
-                passive_deletes=True,
+                cascade="all, delete-orphan",
+                passive_deletes=False,
             )
 
             @classmethod


### PR DESCRIPTION
### About

When deleting a collection, also delete its associated embeddings. Fixes GH-11.

/cc @hammerhead 
