### PR TITLE
Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`

### DIFF
--- a/libs/community/extended_testing_deps.txt
+++ b/libs/community/extended_testing_deps.txt
@@ -14,8 +14,8 @@ chardet>=5.1.0,<6
 cloudpathlib>=0.18,<0.19
 cloudpickle>=2.0.0
 cohere>=4,<6
-crate>=0.34.0,<1
-cratedb-toolkit==0.0.12
+crate==1.0.0dev0
+cratedb-toolkit>=0.0.13,<0.1
 databricks-vectorsearch>=0.21,<0.22
 datasets>=2.15.0,<3
 dgml-utils>=0.3.0,<0.4
@@ -73,6 +73,7 @@ requests-toolbelt>=1.0.0,<2
 rspace_client>=2.5.0,<3
 scikit-learn>=1.2.2,<2
 simsimd>=4.3.1,<5
+sqlalchemy-cratedb>=0.36,<1
 sqlite-vss>=0.1.2,<0.2
 streamlit>=1.18.0,<2
 sympy>=1.12,<2

--- a/libs/community/langchain_community/vectorstores/cratedb/model.py
+++ b/libs/community/langchain_community/vectorstores/cratedb/model.py
@@ -2,7 +2,10 @@ import uuid
 from typing import Any, List, Optional, Tuple
 
 import sqlalchemy
-from crate.client.sqlalchemy.types import ObjectType
+try:
+    from sqlalchemy_cratedb import ObjectType
+except ImportError:
+    from crate.client.sqlalchemy.types import ObjectType
 from sqlalchemy.orm import Session, declarative_base, relationship
 
 from langchain_community.vectorstores.cratedb.sqlalchemy_type import FloatVector

--- a/libs/community/tests/integration_tests/document_loaders/test_sql_database.py
+++ b/libs/community/tests/integration_tests/document_loaders/test_sql_database.py
@@ -47,7 +47,7 @@ except ImportError:
     psycopg2_installed = False
 
 try:
-    import crate.client.sqlalchemy  # noqa: F401
+    import sqlalchemy_cratedb  # noqa: F401
 
     cratedb_installed = True
 except ImportError:


### PR DESCRIPTION
## About
The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch verifies and concludes the migration.

## References
- https://github.com/crate/roadmap/issues/85
